### PR TITLE
Fix response message for when there is NOT a match 

### DIFF
--- a/pages/crush.tsx
+++ b/pages/crush.tsx
@@ -72,7 +72,7 @@ const Home: NextPage = () => {
                         <p className="text-center">
                             Your hash is {crushHash},{" "}
                             <span style={{ color: crushHash === hash ? "#0bc608" : "red" }}>
-                                it&apos;s a {isMatch ? "match!" : "not a match :("}
+                                it&apos;s {isMatch ? "a match!" : "not a match :("}
                             </span>
                         </p>
                     )}


### PR DESCRIPTION
## Description

Minor text changes. 

## How to replicate

1. Create a zk-crush
2. With the newly generated URL, type in an incorrect name
3. The page will say `"it's a not a match :("`.

I have changed it to be `"it's not a match :("`

## Testing

I did **not** test this locally. But, I am confident it will work.

<img width="512" src="https://user-images.githubusercontent.com/17516559/172062161-77a2114e-5bd8-4def-b26d-dac48a44c72c.png" alt="Screenshot of what current page"/>

